### PR TITLE
Fix is_post_revision check

### DIFF
--- a/wp-trigger-github.php
+++ b/wp-trigger-github.php
@@ -41,7 +41,7 @@ class WPTriggerGithub
   function run_hook($post_id)
   {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
-    if (!(wp_is_post_revision($post_id) || wp_is_post_autosave($post_id))) return;
+    if (wp_is_post_revision($post_id) || wp_is_post_autosave($post_id)) return;
 
     $github_token = get_option('option_token');
     $github_username = get_option('option_username');


### PR DESCRIPTION
Fix #2 

According to https://wordpress.stackexchange.com/a/308190/63438

> the term "revision" in Wordpress is a little confusing. It's not the updated, or revised, post... but the older version. 

> So, if you're calling the function wp_is_revision_post() on the current version of the post, it will always return `false`

/cc @gglukmann 