### PR TITLE
Rename event type to wordpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ Save or update action triggers Github repository_dispatch action for triggering 
 - Go to Settings -> General and scroll to bottom
 - Add repository owner name, repository name and generated personal access token
 - If you want to see status badge on dashboard, add workflow name too.
+
+### GitHub Actions configuration
+
+In your GitHub workflow yaml file, you can use this as:
+
+```yml
+on:
+  repository_dispatch:
+    types: [wordpress]
+```

--- a/wp-trigger-github.php
+++ b/wp-trigger-github.php
@@ -52,7 +52,7 @@ class WPTriggerGithub
       $args = array(
         'method'  => 'POST',
         'body'    => json_encode(array(
-          'event_type' => 'dispatch'
+          'event_type' => 'wordpress'
         )),
         'headers' => array(
           'Accept' => 'application/vnd.github.everest-preview+json',


### PR DESCRIPTION
Make this event type more distinguishable from other types.

In github actions, the event type is also used as the build name, so it's more informative to know what triggers to build.

/cc @gglukmann 