### PR TITLE
Fixed bug: Github action firing multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 svn/
+.idea


### PR DESCRIPTION
Hi @gglukmann , great work on the plugin!
I added some code to fix the problem that myself and other users of this plugin have faced: The GitHub action getting triggered multiple times. Here are the changes I made:
- Using the 'wp_after_insert_post' hook instead of 'save_post'. The Wordpress team recommends using this newer hook when listening to events like post updates and creation. You can find more information [here](https://make.wordpress.org/core/2020/11/20/new-action-wp_after_insert_post-in-wordpress-5-6/)
- Firing the specified Github action only if it's been at least 5 seconds it was last fired. For this, the WordPress Options API was used to store a timestamp for the last time the GitHub action was fired and subsequent requests to the runHook function check whether enough time has passed since.

I would appreciate it if you merged these changes as it would benefit the many developers who rely on this plugin. Please let me know if you have any questions!